### PR TITLE
Travis testing + Python 2/3 trove classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+cache: pip
+
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - ./runtests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # itypes
 
+[![Build Status](https://travis-ci.org/tomchristie/itypes.svg?branch=master)](https://travis-ci.org/tomchristie/itypes)
+
 Basic immutable container types for Python.
 
 A simple implementation that's designed for simplicity over performance.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Testing requirements
+flake8
+pytest
+
+# Packaging requirements
+wheel

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,13 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )


### PR DESCRIPTION
**1) Adds support for running tests on Travis**
Example Travis run on my own fork:
https://travis-ci.org/edmorley/itypes/builds/261824100

Before merging Travis will need enabling on this repo, by visiting https://travis-ci.org/profile

Fixes #5.

**2) Adds Python 2/3 trove classifiers to setup.py**

Fixes #6.